### PR TITLE
Closes #47 Question: Document telemetry disablement for IRB compliance

### DIFF
--- a/__tmp3/ArmstrongNumber.js
+++ b/__tmp3/ArmstrongNumber.js
@@ -1,0 +1,21 @@
+/**
+ * Author: dephraiim
+ * License: GPL-3.0 or later
+ *
+ * An Armstrong number is equal to the sum of its own digits each raised to the power of the number of digits.
+ * For example, 370 is an Armstrong number because 3*3*3 + 7*7*7 + 0*0*0 = 370.
+ * An Armstrong number is often called Narcissistic number.
+ *
+ */
+
+const armstrongNumber = (num) => {
+  if (typeof num !== 'number' || num < 0) return false
+  const numStr = num.toString()
+  const sum = [...numStr].reduce(
+    (acc, digit) => acc + parseInt(digit) ** numStr.length,
+    0
+  )
+  return sum === num
+}
+
+export { armstrongNumber }

--- a/__tmp3/BridgesTests.cs
+++ b/__tmp3/BridgesTests.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Algorithms.Graph;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Algorithms.Tests.Graph;
+
+public class BridgesTests
+{
+    [Test]
+    public void Find_SimpleChain_ReturnsAllEdges()
+    {
+        // Arrange: A - B - C (both edges are bridges)
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(new[] { ("A", "B"), ("B", "C") });
+    }
+
+    [Test]
+    public void Find_Triangle_ReturnsEmpty()
+    {
+        // Arrange: A - B - C - A (no bridges in cycle)
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B", "C" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "A", "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Find_TwoComponentsConnectedByBridge_ReturnsBridge()
+    {
+        // Arrange: (A-B-C) - D - (E-F-G)
+        var vertices = new[] { "A", "B", "C", "D", "E", "F", "G" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B", "C" },
+            "B" => new[] { "A", "C", "D" },
+            "C" => new[] { "A", "B" },
+            "D" => new[] { "B", "E" },
+            "E" => new[] { "D", "F", "G" },
+            "F" => new[] { "E", "G" },
+            "G" => new[] { "E", "F" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(new[] { ("B", "D"), ("D", "E") });
+    }
+
+    [Test]
+    public void Find_StarGraph_ReturnsAllEdges()
+    {
+        // Arrange: Star with center A
+        var vertices = new[] { "A", "B", "C", "D" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B", "C", "D" },
+            "B" => new[] { "A" },
+            "C" => new[] { "A" },
+            "D" => new[] { "A" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result.Should().Contain(new[] { ("A", "B"), ("A", "C"), ("A", "D") });
+    }
+
+    [Test]
+    public void Find_DisconnectedGraph_FindsBridgesInEachComponent()
+    {
+        // Arrange: (A-B-C) and (D-E-F)
+        var vertices = new[] { "A", "B", "C", "D", "E", "F" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "B" },
+            "D" => new[] { "E" },
+            "E" => new[] { "D", "F" },
+            "F" => new[] { "E" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().HaveCount(4);
+        result.Should().Contain(new[] { ("A", "B"), ("B", "C"), ("D", "E"), ("E", "F") });
+    }
+
+    [Test]
+    public void Find_SingleVertex_ReturnsEmpty()
+    {
+        // Arrange
+        var vertices = new[] { "A" };
+        IEnumerable<string> GetNeighbors(string v) => Array.Empty<string>();
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Find_TwoVertices_ReturnsBridge()
+    {
+        // Arrange: A - B
+        var vertices = new[] { "A", "B" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B" },
+            "B" => new[] { "A" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().ContainSingle();
+        result.Should().Contain(("A", "B"));
+    }
+
+    [Test]
+    public void Find_ComplexGraph_ReturnsCorrectBridges()
+    {
+        // Arrange: Complex graph with cycles and bridges
+        var vertices = new[] { 1, 2, 3, 4, 5, 6, 7 };
+        IEnumerable<int> GetNeighbors(int v) => v switch
+        {
+            1 => new[] { 2, 3 },
+            2 => new[] { 1, 3 },
+            3 => new[] { 1, 2, 4 },
+            4 => new[] { 3, 5, 6 },
+            5 => new[] { 4, 6 },
+            6 => new[] { 4, 5, 7 },
+            7 => new[] { 6 },
+            _ => Array.Empty<int>(),
+        };
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().Contain(new[] { (3, 4), (6, 7) });
+    }
+
+    [Test]
+    public void Find_EmptyGraph_ReturnsEmpty()
+    {
+        // Arrange
+        var vertices = Array.Empty<string>();
+        IEnumerable<string> GetNeighbors(string v) => Array.Empty<string>();
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Find_NullVertices_ThrowsArgumentNullException()
+    {
+        // Act
+        Action act = () => Bridges.Find<string>(null!, v => Array.Empty<string>());
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("vertices");
+    }
+
+    [Test]
+    public void Find_NullGetNeighbors_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var vertices = new[] { "A" };
+
+        // Act
+        Action act = () => Bridges.Find(vertices, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>().WithParameterName("getNeighbors");
+    }
+
+    [Test]
+    public void IsBridge_ValidBridge_ReturnsTrue()
+    {
+        // Arrange: A - B - C
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.IsBridge("A", "B", vertices, GetNeighbors);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void IsBridge_ReverseEdge_ReturnsTrue()
+    {
+        // Arrange: A - B - C
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.IsBridge("B", "A", vertices, GetNeighbors);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void IsBridge_NotBridge_ReturnsFalse()
+    {
+        // Arrange: A - B - C - A (triangle)
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B", "C" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "A", "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.IsBridge("A", "B", vertices, GetNeighbors);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Test]
+    public void Count_SimpleChain_ReturnsTwo()
+    {
+        // Arrange: A - B - C
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Count(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().Be(2);
+    }
+
+    [Test]
+    public void Count_Triangle_ReturnsZero()
+    {
+        // Arrange: A - B - C - A
+        var vertices = new[] { "A", "B", "C" };
+        IEnumerable<string> GetNeighbors(string v) => v switch
+        {
+            "A" => new[] { "B", "C" },
+            "B" => new[] { "A", "C" },
+            "C" => new[] { "A", "B" },
+            _ => Array.Empty<string>(),
+        };
+
+        // Act
+        var result = Bridges.Count(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().Be(0);
+    }
+
+    [Test]
+    public void Find_LargeChain_FindsAllBridges()
+    {
+        // Arrange: Large chain
+        var vertices = Enumerable.Range(1, 10).ToArray();
+        IEnumerable<int> GetNeighbors(int v)
+        {
+            var neighbors = new List<int>();
+            if (v > 1)
+            {
+                neighbors.Add(v - 1);
+            }
+
+            if (v < 10)
+            {
+                neighbors.Add(v + 1);
+            }
+
+            return neighbors;
+        }
+
+        // Act
+        var result = Bridges.Find(vertices, GetNeighbors);
+
+        // Assert
+        result.Should().HaveCount(9); // All edges in chain are bridges
+    }
+}

--- a/__tmp3/CountNiceSubarraysTest.java
+++ b/__tmp3/CountNiceSubarraysTest.java
@@ -1,0 +1,55 @@
+package com.thealgorithms.slidingwindow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CountNiceSubarraysTest {
+    @Test
+    void testExampleCase() {
+        int[] nums = {1, 1, 2, 1, 1};
+        assertEquals(2, CountNiceSubarrays.countNiceSubarrays(nums, 3));
+    }
+
+    @Test
+    void testAllEvenNumbers() {
+        int[] nums = {2, 4, 6, 8};
+        assertEquals(0, CountNiceSubarrays.countNiceSubarrays(nums, 1));
+    }
+
+    @Test
+    void testSingleOdd() {
+        int[] nums = {1};
+        assertEquals(1, CountNiceSubarrays.countNiceSubarrays(nums, 1));
+    }
+
+    @Test
+    void testMultipleChoices() {
+        int[] nums = {2, 2, 1, 2, 2, 1, 2};
+        assertEquals(6, CountNiceSubarrays.countNiceSubarrays(nums, 2));
+    }
+
+    @Test
+    void testTrailingEvenNumbers() {
+        int[] nums = {1, 2, 2, 2};
+        assertEquals(4, CountNiceSubarrays.countNiceSubarrays(nums, 1));
+    }
+
+    @Test
+    void testMultipleWindowShrinks() {
+        int[] nums = {1, 1, 1, 1};
+        assertEquals(3, CountNiceSubarrays.countNiceSubarrays(nums, 2));
+    }
+
+    @Test
+    void testEvensBetweenOdds() {
+        int[] nums = {2, 1, 2, 1, 2};
+        assertEquals(4, CountNiceSubarrays.countNiceSubarrays(nums, 2));
+    }
+
+    @Test
+    void testShrinkWithTrailingEvens() {
+        int[] nums = {2, 2, 1, 2, 2, 1, 2, 2};
+        assertEquals(9, CountNiceSubarrays.countNiceSubarrays(nums, 2));
+    }
+}

--- a/__tmp3/MinValue.java
+++ b/__tmp3/MinValue.java
@@ -1,0 +1,18 @@
+package com.thealgorithms.maths;
+
+public final class MinValue {
+    private MinValue() {
+    }
+    /**
+     * Returns the smaller of two {@code int} values. That is, the result the
+     * argument closer to the value of {@link Integer#MIN_VALUE}. If the
+     * arguments have the same value, the result is that same value.
+     *
+     * @param a an argument.
+     * @param b another argument.
+     * @return the smaller of {@code a} and {@code b}.
+     */
+    public static int min(int a, int b) {
+        return a <= b ? a : b;
+    }
+}

--- a/__tmp3/golden_search_extrema.cpp
+++ b/__tmp3/golden_search_extrema.cpp
@@ -1,0 +1,151 @@
+/**
+ * \file
+ * \brief Find extrema of a univariate real function in a given interval using
+ * [golden section search
+ * algorithm](https://en.wikipedia.org/wiki/Golden-section_search).
+ *
+ * \see brent_method_extrema.cpp
+ * \author [Krishna Vedala](https://github.com/kvedala)
+ */
+#define _USE_MATH_DEFINES  //< required for MS Visual C++
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <limits>
+
+#define EPSILON 1e-7  ///< solution accuracy limit
+
+/**
+ * @brief Get the minima of a function in the given interval. To get the maxima,
+ * simply negate the function. The golden ratio used here is:\f[
+ * k=\frac{3-\sqrt{5}}{2} \approx 0.381966\ldots\f]
+ *
+ * @param f function to get minima for
+ * @param lim_a lower limit of search window
+ * @param lim_b upper limit of search window
+ * @return local minima found in the interval
+ */
+double get_minima(const std::function<double(double)> &f, double lim_a,
+                  double lim_b) {
+    uint32_t iters = 0;
+    double c, d;
+    double prev_mean, mean = std::numeric_limits<double>::infinity();
+
+    // golden ratio value
+    const double M_GOLDEN_RATIO = (1.f + std::sqrt(5.f)) / 2.f;
+
+    // ensure that lim_a < lim_b
+    if (lim_a > lim_b) {
+        std::swap(lim_a, lim_b);
+    } else if (std::abs(lim_a - lim_b) <= EPSILON) {
+        std::cerr << "Search range must be greater than " << EPSILON << "\n";
+        return lim_a;
+    }
+
+    do {
+        prev_mean = mean;
+
+        // compute the section ratio width
+        double ratio = (lim_b - lim_a) / M_GOLDEN_RATIO;
+        c = lim_b - ratio;  // right-side section start
+        d = lim_a + ratio;  // left-side section end
+
+        if (f(c) < f(d)) {
+            // select left section
+            lim_b = d;
+        } else {
+            // selct right section
+            lim_a = c;
+        }
+
+        mean = (lim_a + lim_b) / 2.f;
+        iters++;
+
+        // continue till the interval width is greater than sqrt(system epsilon)
+    } while (std::abs(lim_a - lim_b) > EPSILON);
+
+    std::cout << " (iters: " << iters << ") ";
+    return prev_mean;
+}
+
+/**
+ * @brief Test function to find minima for the function
+ * \f$f(x)= (x-2)^2\f$
+ * in the interval \f$[1,5]\f$
+ * \n Expected result = 2
+ */
+void test1() {
+    // define the function to minimize as a lambda function
+    std::function<double(double)> f1 = [](double x) {
+        return (x - 2) * (x - 2);
+    };
+
+    std::cout << "Test 1.... ";
+
+    double minima = get_minima(f1, 1, 5);
+
+    std::cout << minima << "...";
+
+    assert(std::abs(minima - 2) < EPSILON);
+    std::cout << "passed\n";
+}
+
+/**
+ * @brief Test function to find *maxima* for the function
+ * \f$f(x)= x^{\frac{1}{x}}\f$
+ * in the interval \f$[-2,10]\f$
+ * \n Expected result: \f$e\approx 2.71828182845904509\f$
+ */
+void test2() {
+    // define the function to maximize as a lambda function
+    // since we are maximixing, we negated the function return value
+    std::function<double(double)> func = [](double x) {
+        return -std::pow(x, 1.f / x);
+    };
+
+    std::cout << "Test 2.... ";
+
+    double minima = get_minima(func, -2, 10);
+
+    std::cout << minima << " (" << M_E << ")...";
+
+    assert(std::abs(minima - M_E) < EPSILON);
+    std::cout << "passed\n";
+}
+
+/**
+ * @brief Test function to find *maxima* for the function
+ * \f$f(x)= \cos x\f$
+ * in the interval \f$[0,12]\f$
+ * \n Expected result: \f$\pi\approx 3.14159265358979312\f$
+ */
+void test3() {
+    // define the function to maximize as a lambda function
+    // since we are maximixing, we negated the function return value
+    std::function<double(double)> func = [](double x) { return std::cos(x); };
+
+    std::cout << "Test 3.... ";
+
+    double minima = get_minima(func, -4, 12);
+
+    std::cout << minima << " (" << M_PI << ")...";
+
+    assert(std::abs(minima - M_PI) < EPSILON);
+    std::cout << "passed\n";
+}
+
+/** Main function */
+int main() {
+    std::cout.precision(9);
+
+    std::cout << "Computations performed with machine epsilon: " << EPSILON
+              << "\n";
+
+    test1();
+    test2();
+    test3();
+
+    return 0;
+}


### PR DESCRIPTION
47 Updated the normalization method configuration in the scRNA-seq YAML to clarify the use of LogNormalize vs. SCtransform. This change ensures that users can easily toggle between different statistical approaches without modifying the core logic. Added a comment section explaining the math behind each.