### PR TITLE
Closes #87 Create contributing guidelines for bioinformatics pipelines

### DIFF
--- a/__future5/BellNumbersTest.java
+++ b/__future5/BellNumbersTest.java
@@ -1,0 +1,53 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class BellNumbersTest {
+
+    @Test
+    void testStandardCases() {
+        // Base cases and small numbers
+        assertEquals(1, BellNumbers.compute(0));
+        assertEquals(1, BellNumbers.compute(1));
+        assertEquals(2, BellNumbers.compute(2));
+        assertEquals(5, BellNumbers.compute(3));
+        assertEquals(15, BellNumbers.compute(4));
+        assertEquals(52, BellNumbers.compute(5));
+    }
+
+    @Test
+    void testMediumNumber() {
+        // B10 = 115,975
+        assertEquals(115975, BellNumbers.compute(10));
+        // B15 = 1,382,958,545
+        assertEquals(1382958545L, BellNumbers.compute(15));
+    }
+
+    @Test
+    void testLargeNumber() {
+        // B20 = 51,724,158,235,372
+        // We use the 'L' suffix to tell Java this is a long literal
+        assertEquals(51724158235372L, BellNumbers.compute(20));
+    }
+
+    @Test
+    void testMaxLongCapacity() {
+        // B25 is the largest Bell number that fits in a Java long (signed 64-bit)
+        // B25 = 4,638,590,332,229,999,353
+        assertEquals(4638590332229999353L, BellNumbers.compute(25));
+    }
+
+    @Test
+    void testNegativeInput() {
+        assertThrows(IllegalArgumentException.class, () -> BellNumbers.compute(-1));
+    }
+
+    @Test
+    void testOverflowProtection() {
+        // We expect an exception if the user asks for the impossible
+        assertThrows(IllegalArgumentException.class, () -> BellNumbers.compute(26));
+    }
+}

--- a/__future5/topological_test.go
+++ b/__future5/topological_test.go
@@ -1,0 +1,59 @@
+package graph
+
+import (
+	"testing"
+)
+
+var testCases = []struct {
+	name        string
+	N           int
+	constraints [][]int
+}{
+	{
+		"basic test", 2,
+		[][]int{{1, 0}},
+	},
+	{
+		"double path", 7,
+		[][]int{
+			{0, 1}, {1, 3}, {3, 5},
+			{0, 2}, {2, 4}, {4, 6}},
+	},
+	{
+		"star shape", 7,
+		[][]int{
+			{0, 1}, {0, 3}, {0, 5},
+			{0, 2}, {0, 4}, {0, 6}},
+	},
+	{
+		"tree shape", 7,
+		[][]int{
+			{0, 1}, {1, 3}, {1, 5},
+			{0, 2}, {2, 4}, {2, 6}},
+	},
+}
+
+func TestTopological(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := Topological(tc.N, tc.constraints)
+
+			visited := make([]bool, tc.N)
+			positions := make([]int, tc.N)
+			for i := 0; i < tc.N; i++ {
+				positions[actual[i]] = i
+				visited[actual[i]] = true
+			}
+			for _, v := range visited {
+				if !v {
+					t.Errorf("nodes not all visited, %v", visited)
+				}
+			}
+			for _, c := range tc.constraints {
+				if positions[c[0]] > positions[c[1]] {
+					t.Errorf("%v dun satisfy %v", actual, c)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
87 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.